### PR TITLE
feat: added support for enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For example, if you had a Go backend that used the [Gin](https://www.github.com/
 * Support for custom logging
 * Support for custom status codes _they must be defined as constants/only defined once (`http.StatusX` is perfect, or `200`)_
 * Support for comments in struct fields and above named types
-* Support for enum-like named types (e.g. `type Status string` and `const (StatusOK Status = "OK")` etc.) to be parsed as enums
+* Support for enum-like named types (e.g. `type Status string` and `const (StatusOK Status = "OK")` etc.) to be parsed as enums _if they are defined in the same package!_
 
 ## Supported Formats
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For example, if you had a Go backend that used the [Gin](https://www.github.com/
 * Support for custom logging
 * Support for custom status codes _they must be defined as constants/only defined once (`http.StatusX` is perfect, or `200`)_
 * Support for comments in struct fields and above named types
+* Support for enum-like named types (e.g. `type Status string` and `const (StatusOK Status = "OK")` etc.) to be parsed as enums
 
 ## Supported Formats
 

--- a/astTraversal/result.go
+++ b/astTraversal/result.go
@@ -26,7 +26,7 @@ type Result struct {
 
 	// EnumValues is a list of enum values (e.g. for an enum { Foo, Bar })
 	// This is used for when the result of a types.Named becomes a types.Basic and has constant values defined in the package
-	EnumValues []string
+	EnumValues []any
 
 	// MapKeyPackage is the package of the map key (e.g. for a map[string]string)
 	MapKeyPackage *PackageNode

--- a/astTraversal/result.go
+++ b/astTraversal/result.go
@@ -24,6 +24,10 @@ type Result struct {
 	// ConstantValue is the constant value of the result (e.g. for a string)
 	ConstantValue string
 
+	// EnumValues is a list of enum values (e.g. for an enum { Foo, Bar })
+	// This is used for when the result of a types.Named becomes a types.Basic and has constant values defined in the package
+	EnumValues []string
+
 	// MapKeyPackage is the package of the map key (e.g. for a map[string]string)
 	MapKeyPackage *PackageNode
 

--- a/astTraversal/type.go
+++ b/astTraversal/type.go
@@ -4,6 +4,8 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"strconv"
+	"strings"
 )
 
 type TypeTraverser struct {
@@ -72,7 +74,47 @@ func (t *TypeTraverser) Result() (Result, error) {
 											for _, value := range valueSpec.Values {
 												// If the value is a basic literal, we add it to the enum values
 												if basicLit, ok := value.(*ast.BasicLit); ok {
-													result.EnumValues = append(result.EnumValues, basicLit.Value)
+													// Switch over the basic literal's kind to determine the type of the value
+													// And format it accordingly
+													switch n.Kind() {
+													case types.String:
+														result.EnumValues = append(result.EnumValues, strings.Trim(basicLit.Value, "\""))
+													case types.Int:
+														i, err := strconv.Atoi(basicLit.Value)
+														if err != nil {
+															continue
+														}
+
+														result.EnumValues = append(result.EnumValues, i)
+													case types.Float32, types.Float64:
+														f, err := strconv.ParseFloat(basicLit.Value, 64)
+														if err != nil {
+															continue
+														}
+
+														result.EnumValues = append(result.EnumValues, f)
+													case types.Bool:
+														b, err := strconv.ParseBool(basicLit.Value)
+														if err != nil {
+															continue
+														}
+
+														result.EnumValues = append(result.EnumValues, b)
+													case types.Int8, types.Int16, types.Int32, types.Int64:
+														i, err := strconv.ParseInt(basicLit.Value, 10, 64)
+														if err != nil {
+															continue
+														}
+
+														result.EnumValues = append(result.EnumValues, i)
+													case types.Uint, types.Uint8, types.Uint16, types.Uint32, types.Uint64:
+														i, err := strconv.ParseUint(basicLit.Value, 10, 64)
+														if err != nil {
+															continue
+														}
+
+														result.EnumValues = append(result.EnumValues, i)
+													}
 												}
 											}
 										}

--- a/outputs/openapi/components.go
+++ b/outputs/openapi/components.go
@@ -1,8 +1,6 @@
 package openapi
 
 import (
-	"github.com/ls6-events/astra"
-	"strconv"
 	"strings"
 )
 
@@ -14,38 +12,4 @@ func makeComponentRef(name, pkg string) string {
 // makeComponentRefName converts the component and package name to a valid OpenAPI reference name (to avoid collisions)
 func makeComponentRefName(name, pkg string) string {
 	return strings.ReplaceAll(pkg, "/", "_") + "." + name
-}
-
-func mapComponentEnums(component astra.Field) []interface{} {
-	var enums []interface{}
-	for _, enum := range component.EnumValues {
-		schema := mapAcceptedType(component.Type)
-		switch schema.Type {
-		case "string":
-			enums = append(enums, strings.Trim(enum, "\""))
-		case "integer":
-			i, err := strconv.Atoi(enum)
-			if err != nil {
-				continue
-			}
-
-			enums = append(enums, i)
-		case "number":
-			f, err := strconv.ParseFloat(enum, 64)
-			if err != nil {
-				continue
-			}
-
-			enums = append(enums, f)
-		case "boolean":
-			b, err := strconv.ParseBool(enum)
-			if err != nil {
-				continue
-			}
-
-			enums = append(enums, b)
-		}
-	}
-
-	return enums
 }

--- a/outputs/openapi/components.go
+++ b/outputs/openapi/components.go
@@ -1,6 +1,10 @@
 package openapi
 
-import "strings"
+import (
+	"github.com/ls6-events/astra"
+	"strconv"
+	"strings"
+)
 
 // makeComponentRef creates a reference to the component in the OpenAPI specification
 func makeComponentRef(name, pkg string) string {
@@ -10,4 +14,38 @@ func makeComponentRef(name, pkg string) string {
 // makeComponentRefName converts the component and package name to a valid OpenAPI reference name (to avoid collisions)
 func makeComponentRefName(name, pkg string) string {
 	return strings.ReplaceAll(pkg, "/", "_") + "." + name
+}
+
+func mapComponentEnums(component astra.Field) []interface{} {
+	var enums []interface{}
+	for _, enum := range component.EnumValues {
+		schema := mapAcceptedType(component.Type)
+		switch schema.Type {
+		case "string":
+			enums = append(enums, strings.Trim(enum, "\""))
+		case "integer":
+			i, err := strconv.Atoi(enum)
+			if err != nil {
+				continue
+			}
+
+			enums = append(enums, i)
+		case "number":
+			f, err := strconv.ParseFloat(enum, 64)
+			if err != nil {
+				continue
+			}
+
+			enums = append(enums, f)
+		case "boolean":
+			b, err := strconv.ParseBool(enum)
+			if err != nil {
+				continue
+			}
+
+			enums = append(enums, b)
+		}
+	}
+
+	return enums
 }

--- a/outputs/openapi/generate.go
+++ b/outputs/openapi/generate.go
@@ -283,7 +283,7 @@ func componentToSchema(component astra.Field) Schema {
 				Ref: makeComponentRef(component.Type, component.Package),
 			}
 		} else {
-			schema.Enum = mapComponentEnums(component)
+			schema.Enum = component.EnumValues
 		}
 	}
 

--- a/outputs/openapi/generate.go
+++ b/outputs/openapi/generate.go
@@ -282,6 +282,8 @@ func componentToSchema(component astra.Field) Schema {
 			schema = Schema{
 				Ref: makeComponentRef(component.Type, component.Package),
 			}
+		} else {
+			schema.Enum = mapComponentEnums(component)
 		}
 	}
 

--- a/types.go
+++ b/types.go
@@ -56,7 +56,7 @@ type Field struct {
 	Type    string `json:"type,omitempty" yaml:"type,omitempty"`
 	Name    string `json:"name,omitempty" yaml:"name,omitempty"`
 
-	EnumValues []string `json:"enumValues,omitempty" yaml:"enumValues,omitempty"`
+	EnumValues []any `json:"enumValues,omitempty" yaml:"enumValues,omitempty"`
 
 	IsRequired bool `json:"isRequired,omitempty" yaml:"isRequired,omitempty"`
 	IsEmbedded bool `json:"isEmbedded,omitempty" yaml:"isEmbedded,omitempty"`

--- a/types.go
+++ b/types.go
@@ -56,6 +56,8 @@ type Field struct {
 	Type    string `json:"type,omitempty" yaml:"type,omitempty"`
 	Name    string `json:"name,omitempty" yaml:"name,omitempty"`
 
+	EnumValues []string `json:"enumValues,omitempty" yaml:"enumValues,omitempty"`
+
 	IsRequired bool `json:"isRequired,omitempty" yaml:"isRequired,omitempty"`
 	IsEmbedded bool `json:"isEmbedded,omitempty" yaml:"isEmbedded,omitempty"`
 

--- a/utils.go
+++ b/utils.go
@@ -22,6 +22,7 @@ func ParseResultToField(result astTraversal.Result) Field {
 	field := Field{
 		Type:         result.Type,
 		Name:         result.Name,
+		EnumValues:   result.EnumValues,
 		IsRequired:   result.IsRequired,
 		IsEmbedded:   result.IsEmbedded,
 		SliceType:    result.SliceType,


### PR DESCRIPTION
Added support for enum-like validation using the syntax:

```go
type Status string

const (
	StatusOK Status = "ok"
	StatusErr Status = "error"
)
```

Any basic type that can be a constant is valid here (string, intX, floatX and bool) but the values have to be defined in the same package as the type declaration. A limitation of this implementatation.