### PR TITLE
feat: added headers and abort support

### DIFF
--- a/inputs/gin/parseFunction.go
+++ b/inputs/gin/parseFunction.go
@@ -469,6 +469,108 @@ func parseFunction(s *astra.Service, funcTraverser *astTraversal.FunctionTravers
 					if err != nil {
 						return false
 					}
+				case "GetHeader":
+					currRoute, err = funcBuilder.Value().Build(func(route *astra.Route, params []any) (*astra.Route, error) {
+						name := params[0].(string)
+
+						param := astra.Param{
+							Field: astra.Field{
+								Type: "string",
+							},
+							Name: name,
+						}
+
+						route.RequestHeaders = append(route.RequestHeaders, param)
+
+						return route, nil
+					})
+					if err != nil {
+						return false
+					}
+				case "ShouldBindHeader":
+					fallthrough
+				case "BindHeader":
+					currRoute, err = funcBuilder.ExpressionResult().Build(func(route *astra.Route, params []any) (*astra.Route, error) {
+						field := astra.ParseResultToField(params[0].(astTraversal.Result))
+
+						route.RequestHeaders = append(route.RequestHeaders, astra.Param{
+							IsBound: true,
+							Field:   field,
+						})
+
+						return route, nil
+					})
+					if err != nil {
+						return false
+					}
+				case "Header":
+					currRoute, err = funcBuilder.Value().Build(func(route *astra.Route, params []any) (*astra.Route, error) {
+						name := params[0].(string)
+
+						param := astra.Param{
+							Field: astra.Field{
+								Type: "string",
+							},
+							Name: name,
+						}
+
+						route.ResponseHeaders = append(route.ResponseHeaders, param)
+
+						return route, nil
+					})
+				case "AbortWithError":
+					currRoute, err = funcBuilder.StatusCode().Ignored().Build(func(route *astra.Route, params []any) (*astra.Route, error) {
+						statusCode := params[0].(int)
+
+						returnType := astra.ReturnType{
+							StatusCode: statusCode,
+							Field: astra.Field{
+								Type: "nil",
+							},
+						}
+
+						route.ReturnTypes = astra.AddReturnType(route.ReturnTypes, returnType)
+
+						return route, nil
+					})
+					if err != nil {
+						return false
+					}
+				case "AbortWithStatus":
+					currRoute, err = funcBuilder.StatusCode().Build(func(route *astra.Route, params []any) (*astra.Route, error) {
+						statusCode := params[0].(int)
+
+						returnType := astra.ReturnType{
+							StatusCode: statusCode,
+							Field: astra.Field{
+								Type: "nil",
+							},
+						}
+
+						route.ReturnTypes = astra.AddReturnType(route.ReturnTypes, returnType)
+
+						return route, nil
+					})
+					if err != nil {
+						return false
+					}
+				case "AbortWithStatusJSON":
+					currRoute, err = funcBuilder.StatusCode().ExpressionResult().Build(func(route *astra.Route, params []any) (*astra.Route, error) {
+						statusCode := params[0].(int)
+						result := params[1].(astTraversal.Result)
+
+						returnType := astra.ReturnType{
+							StatusCode: statusCode,
+							Field:      astra.ParseResultToField(result),
+						}
+
+						route.ReturnTypes = astra.AddReturnType(route.ReturnTypes, returnType)
+
+						return route, nil
+					})
+					if err != nil {
+						return false
+					}
 				}
 			}
 		}

--- a/outputs/openapi/types.go
+++ b/outputs/openapi/types.go
@@ -120,6 +120,7 @@ type Header struct {
 	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
 	Deprecated  bool   `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 	AllowEmpty  bool   `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	Schema      Schema `json:"schema,omitempty" yaml:"schema,omitempty"`
 }
 
 // Responses is the OpenAPI responses

--- a/types.go
+++ b/types.go
@@ -16,6 +16,9 @@ type Route struct {
 	Body        []Param      `json:"body,omitempty" yaml:"body,omitempty"`
 	ReturnTypes []ReturnType `json:"returnTypes,omitempty" yaml:"returnTypes,omitempty"`
 	Doc         string       `json:"doc,omitempty" yaml:"doc,omitempty"`
+
+	RequestHeaders  []Param `json:"requestHeaders,omitempty" yaml:"requestHeaders,omitempty"`
+	ResponseHeaders []Param `json:"responseHeaders,omitempty" yaml:"responseHeaders,omitempty"`
 }
 
 // ReturnType is a return type for a route


### PR DESCRIPTION
- Added support for request and response headers, but no method to validate which response code is representational of which header, so it's all for all right now.
- Added support for `AbortWithStatus`, `AbortWithError` and `AbortWithStatusJSON` methods.