### PR TITLE
feat: added better struct naming based on collision avoidance

### DIFF
--- a/examples/basic/openapi.generated.yaml
+++ b/examples/basic/openapi.generated.yaml
@@ -17,7 +17,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/github.com_gin-gonic_gin.H'
+                                $ref: '#/components/schemas/gin.H'
     /posts:
         get:
             operationId: getPosts
@@ -29,21 +29,21 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/basic_types.Post'
+                                    $ref: '#/components/schemas/types.Post'
         post:
             operationId: createPost
             requestBody:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/basic_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/basic_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -65,7 +65,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/basic_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -84,14 +84,14 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/basic_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/basic_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -117,7 +117,13 @@ paths:
                                 type: string
 components:
     schemas:
-        basic_types.Author:
+        gin.H:
+            type: object
+            additionalProperties: {}
+        time.Time:
+            type: string
+            format: date-time
+        types.Author:
             type: object
             properties:
                 first_name:
@@ -127,27 +133,27 @@ components:
                     format: int32
                 last_name:
                     type: string
-        basic_types.Comment:
+        types.Comment:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/basic_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 id:
                     type: integer
                     format: int32
-        basic_types.Post:
+        types.Post:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/basic_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 comments:
                     type: array
                     items:
-                        $ref: '#/components/schemas/basic_types.Comment'
+                        $ref: '#/components/schemas/types.Comment'
                 id:
                     type: integer
                     format: int32
@@ -155,7 +161,7 @@ components:
                     type: string
                 published_at:
                     $ref: '#/components/schemas/time.Time'
-        basic_types.PostDTO:
+        types.PostDTO:
             type: object
             properties:
                 author_id:
@@ -165,9 +171,3 @@ components:
                     type: string
                 name:
                     type: string
-        github.com_gin-gonic_gin.H:
-            type: object
-            additionalProperties: {}
-        time.Time:
-            type: string
-            format: date-time

--- a/examples/with-azure-functions/openapi.generated.yaml
+++ b/examples/with-azure-functions/openapi.generated.yaml
@@ -17,7 +17,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/github.com_gin-gonic_gin.H'
+                                $ref: '#/components/schemas/gin.H'
     /posts:
         get:
             operationId: getPosts
@@ -29,21 +29,21 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/azurefunctions_types.Post'
+                                    $ref: '#/components/schemas/types.Post'
         post:
             operationId: createPost
             requestBody:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/azurefunctions_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/azurefunctions_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -65,7 +65,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/azurefunctions_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -84,14 +84,14 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/azurefunctions_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/azurefunctions_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -117,7 +117,57 @@ paths:
                                 type: string
 components:
     schemas:
-        azurefunctions_types.Author:
+        gin.H:
+            type: object
+            additionalProperties: {}
+        time.Time:
+            type: string
+            format: date-time
+            description: |-
+                A Time represents an instant in time with nanosecond precision.
+
+                Programs using times should typically store and pass them as values,
+                not pointers. That is, time variables and struct fields should be of
+                type time.Time, not *time.Time.
+
+                A Time value can be used by multiple goroutines simultaneously except
+                that the methods GobDecode, UnmarshalBinary, UnmarshalJSON and
+                UnmarshalText are not concurrency-safe.
+
+                Time instants can be compared using the Before, After, and Equal methods.
+                The Sub method subtracts two instants, producing a Duration.
+                The Add method adds a Time and a Duration, producing a Time.
+
+                The zero value of type Time is January 1, year 1, 00:00:00.000000000 UTC.
+                As this time is unlikely to come up in practice, the IsZero method gives
+                a simple way of detecting a time that has not been initialized explicitly.
+
+                Each Time has associated with it a Location, consulted when computing the
+                presentation form of the time, such as in the Format, Hour, and Year methods.
+                The methods Local, UTC, and In return a Time with a specific location.
+                Changing the location in this way changes only the presentation; it does not
+                change the instant in time being denoted and therefore does not affect the
+                computations described in earlier paragraphs.
+
+                Representations of a Time value saved by the GobEncode, MarshalBinary,
+                MarshalJSON, and MarshalText methods store the Time.Location's offset, but not
+                the location name. They therefore lose information about Daylight Saving Time.
+
+                In addition to the required “wall clock” reading, a Time may contain an optional
+                reading of the current process's monotonic clock, to provide additional precision
+                for comparison or subtraction.
+                See the “Monotonic Clocks” section in the package documentation for details.
+
+                Note that the Go == operator compares not just the time instant but also the
+                Location and the monotonic clock reading. Therefore, Time values should not
+                be used as map or database keys without first guaranteeing that the
+                identical Location has been set for all values, which can be achieved
+                through use of the UTC or Local method, and that the monotonic clock reading
+                has been stripped by setting t = t.Round(0). In general, prefer t.Equal(u)
+                to t == u, since t.Equal uses the most accurate comparison available and
+                correctly handles the case when only one of its arguments has a monotonic
+                clock reading.
+        types.Author:
             type: object
             properties:
                 first_name:
@@ -127,27 +177,27 @@ components:
                     format: int32
                 last_name:
                     type: string
-        azurefunctions_types.Comment:
+        types.Comment:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/azurefunctions_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 id:
                     type: integer
                     format: int32
-        azurefunctions_types.Post:
+        types.Post:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/azurefunctions_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 comments:
                     type: array
                     items:
-                        $ref: '#/components/schemas/azurefunctions_types.Comment'
+                        $ref: '#/components/schemas/types.Comment'
                 id:
                     type: integer
                     format: int32
@@ -155,7 +205,7 @@ components:
                     type: string
                 published_at:
                     $ref: '#/components/schemas/time.Time'
-        azurefunctions_types.PostDTO:
+        types.PostDTO:
             type: object
             properties:
                 author_id:
@@ -165,9 +215,3 @@ components:
                     type: string
                 name:
                     type: string
-        github.com_gin-gonic_gin.H:
-            type: object
-            additionalProperties: {}
-        time.Time:
-            type: string
-            format: date-time

--- a/examples/with-cache/openapi.generated.yaml
+++ b/examples/with-cache/openapi.generated.yaml
@@ -17,7 +17,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/github.com_gin-gonic_gin.H'
+                                $ref: '#/components/schemas/gin.H'
     /posts:
         get:
             operationId: getPosts
@@ -29,21 +29,21 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/withcache_types.Post'
+                                    $ref: '#/components/schemas/types.Post'
         post:
             operationId: createPost
             requestBody:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/withcache_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcache_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -65,7 +65,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcache_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -84,14 +84,14 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/withcache_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcache_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -117,13 +117,13 @@ paths:
                                 type: string
 components:
     schemas:
-        github.com_gin-gonic_gin.H:
+        gin.H:
             type: object
             additionalProperties: {}
         time.Time:
             type: string
             format: date-time
-        withcache_types.Author:
+        types.Author:
             type: object
             properties:
                 first_name:
@@ -133,27 +133,27 @@ components:
                     format: int32
                 last_name:
                     type: string
-        withcache_types.Comment:
+        types.Comment:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/withcache_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 id:
                     type: integer
                     format: int32
-        withcache_types.Post:
+        types.Post:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/withcache_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 comments:
                     type: array
                     items:
-                        $ref: '#/components/schemas/withcache_types.Comment'
+                        $ref: '#/components/schemas/types.Comment'
                 id:
                     type: integer
                     format: int32
@@ -161,7 +161,7 @@ components:
                     type: string
                 published_at:
                     $ref: '#/components/schemas/time.Time'
-        withcache_types.PostDTO:
+        types.PostDTO:
             type: object
             properties:
                 author_id:

--- a/examples/with-cli/openapi.generated.yaml
+++ b/examples/with-cli/openapi.generated.yaml
@@ -17,7 +17,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/github.com_gin-gonic_gin.H'
+                                $ref: '#/components/schemas/gin.H'
     /posts:
         get:
             operationId: getPosts
@@ -29,21 +29,21 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/withcli_types.Post'
+                                    $ref: '#/components/schemas/types.Post'
         post:
             operationId: createPost
             requestBody:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/withcli_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcli_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -65,7 +65,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcli_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -84,14 +84,14 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/withcli_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcli_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -117,13 +117,13 @@ paths:
                                 type: string
 components:
     schemas:
-        github.com_gin-gonic_gin.H:
+        gin.H:
             type: object
             additionalProperties: {}
         time.Time:
             type: string
             format: date-time
-        withcli_types.Author:
+        types.Author:
             type: object
             properties:
                 first_name:
@@ -133,27 +133,27 @@ components:
                     format: int32
                 last_name:
                     type: string
-        withcli_types.Comment:
+        types.Comment:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/withcli_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 id:
                     type: integer
                     format: int32
-        withcli_types.Post:
+        types.Post:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/withcli_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 comments:
                     type: array
                     items:
-                        $ref: '#/components/schemas/withcli_types.Comment'
+                        $ref: '#/components/schemas/types.Comment'
                 id:
                     type: integer
                     format: int32
@@ -161,7 +161,7 @@ components:
                     type: string
                 published_at:
                     $ref: '#/components/schemas/time.Time'
-        withcli_types.PostDTO:
+        types.PostDTO:
             type: object
             properties:
                 author_id:

--- a/examples/with-cobra/openapi.generated.yaml
+++ b/examples/with-cobra/openapi.generated.yaml
@@ -17,7 +17,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/github.com_gin-gonic_gin.H'
+                                $ref: '#/components/schemas/gin.H'
     /posts:
         get:
             operationId: getPosts
@@ -29,21 +29,21 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/withcobra_types.Post'
+                                    $ref: '#/components/schemas/types.Post'
         post:
             operationId: createPost
             requestBody:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/withcobra_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcobra_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -65,7 +65,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcobra_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -84,14 +84,14 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/withcobra_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcobra_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -117,13 +117,13 @@ paths:
                                 type: string
 components:
     schemas:
-        github.com_gin-gonic_gin.H:
+        gin.H:
             type: object
             additionalProperties: {}
         time.Time:
             type: string
             format: date-time
-        withcobra_types.Author:
+        types.Author:
             type: object
             properties:
                 first_name:
@@ -133,27 +133,27 @@ components:
                     format: int32
                 last_name:
                     type: string
-        withcobra_types.Comment:
+        types.Comment:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/withcobra_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 id:
                     type: integer
                     format: int32
-        withcobra_types.Post:
+        types.Post:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/withcobra_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 comments:
                     type: array
                     items:
-                        $ref: '#/components/schemas/withcobra_types.Comment'
+                        $ref: '#/components/schemas/types.Comment'
                 id:
                     type: integer
                     format: int32
@@ -161,7 +161,7 @@ components:
                     type: string
                 published_at:
                     $ref: '#/components/schemas/time.Time'
-        withcobra_types.PostDTO:
+        types.PostDTO:
             type: object
             properties:
                 author_id:

--- a/examples/with-custom-functions/openapi.generated.yaml
+++ b/examples/with-custom-functions/openapi.generated.yaml
@@ -17,7 +17,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/github.com_gin-gonic_gin.H'
+                                $ref: '#/components/schemas/gin.H'
     /posts:
         get:
             operationId: getPosts
@@ -29,21 +29,21 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/withcustomfunctions_types.Post'
+                                    $ref: '#/components/schemas/types.Post'
         post:
             operationId: createPost
             requestBody:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/withcustomfunctions_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "201":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcustomfunctions_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -65,7 +65,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcustomfunctions_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -84,14 +84,14 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/withcustomfunctions_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withcustomfunctions_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -117,14 +117,13 @@ paths:
                                 type: string
 components:
     schemas:
-        github.com_gin-gonic_gin.H:
+        gin.H:
             type: object
             additionalProperties: {}
-            description: H is a shortcut for map[string]any
         time.Time:
             type: string
             format: date-time
-        withcustomfunctions_types.Author:
+        types.Author:
             type: object
             properties:
                 first_name:
@@ -134,27 +133,27 @@ components:
                     format: int32
                 last_name:
                     type: string
-        withcustomfunctions_types.Comment:
+        types.Comment:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/withcustomfunctions_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 id:
                     type: integer
                     format: int32
-        withcustomfunctions_types.Post:
+        types.Post:
             type: object
             properties:
                 author:
-                    $ref: '#/components/schemas/withcustomfunctions_types.Author'
+                    $ref: '#/components/schemas/types.Author'
                 body:
                     type: string
                 comments:
                     type: array
                     items:
-                        $ref: '#/components/schemas/withcustomfunctions_types.Comment'
+                        $ref: '#/components/schemas/types.Comment'
                 id:
                     type: integer
                     format: int32
@@ -162,7 +161,7 @@ components:
                     type: string
                 published_at:
                     $ref: '#/components/schemas/time.Time'
-        withcustomfunctions_types.PostDTO:
+        types.PostDTO:
             type: object
             properties:
                 author_id:

--- a/examples/with-gorm/openapi.generated.yaml
+++ b/examples/with-gorm/openapi.generated.yaml
@@ -17,7 +17,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/github.com_gin-gonic_gin.H'
+                                $ref: '#/components/schemas/gin.H'
     /posts:
         get:
             operationId: getPosts
@@ -29,7 +29,7 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: '#/components/schemas/withgorm_types.Post'
+                                    $ref: '#/components/schemas/types.Post'
                 "500":
                     description: ""
                     content:
@@ -42,14 +42,14 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/withgorm_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withgorm_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -77,7 +77,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withgorm_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -102,14 +102,14 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/withgorm_types.PostDTO'
+                            $ref: '#/components/schemas/types.PostDTO'
             responses:
                 "200":
                     description: ""
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/withgorm_types.Post'
+                                $ref: '#/components/schemas/types.Post'
                 "400":
                     description: ""
                     content:
@@ -147,23 +147,23 @@ paths:
                                 type: string
 components:
     schemas:
-        github.com_gin-gonic_gin.H:
+        gin.H:
             type: object
             additionalProperties: {}
-        gorm.io_gorm.DeletedAt:
+        gorm.DeletedAt:
             type: object
             properties:
                 Time:
                     $ref: '#/components/schemas/time.Time'
                 Valid:
                     type: boolean
-        gorm.io_gorm.Model:
+        gorm.Model:
             type: object
             properties:
                 CreatedAt:
                     $ref: '#/components/schemas/time.Time'
                 DeletedAt:
-                    $ref: '#/components/schemas/gorm.io_gorm.DeletedAt'
+                    $ref: '#/components/schemas/gorm.DeletedAt'
                 ID:
                     type: integer
                     format: uint
@@ -172,42 +172,42 @@ components:
         time.Time:
             type: string
             format: date-time
-        withgorm_types.Author:
+        types.Author:
             type: object
             allOf:
-                - $ref: '#/components/schemas/gorm.io_gorm.Model'
+                - $ref: '#/components/schemas/gorm.Model'
                 - properties:
                     first_name:
                         type: string
                     last_name:
                         type: string
-        withgorm_types.Comment:
+        types.Comment:
             type: object
             allOf:
-                - $ref: '#/components/schemas/gorm.io_gorm.Model'
+                - $ref: '#/components/schemas/gorm.Model'
                 - properties:
                     author:
-                        $ref: '#/components/schemas/withgorm_types.Author'
+                        $ref: '#/components/schemas/types.Author'
                     body:
                         type: string
-        withgorm_types.Post:
+        types.Post:
             type: object
             allOf:
-                - $ref: '#/components/schemas/gorm.io_gorm.Model'
+                - $ref: '#/components/schemas/gorm.Model'
                 - properties:
                     author:
-                        $ref: '#/components/schemas/withgorm_types.Author'
+                        $ref: '#/components/schemas/types.Author'
                     body:
                         type: string
                     comments:
                         type: array
                         items:
-                            $ref: '#/components/schemas/withgorm_types.Comment'
+                            $ref: '#/components/schemas/types.Comment'
                     name:
                         type: string
                     published_at:
                         $ref: '#/components/schemas/time.Time'
-        withgorm_types.PostDTO:
+        types.PostDTO:
             type: object
             properties:
                 author_id:

--- a/examples/with-swagger-ui/swaggerui/swagger.json
+++ b/examples/with-swagger-ui/swaggerui/swagger.json
@@ -23,7 +23,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github.com_gin-gonic_gin.H"
+                  "$ref": "#/components/schemas/gin.H"
                 }
               }
             }
@@ -42,7 +42,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/withswaggerui_types.Post"
+                    "$ref": "#/components/schemas/types.Post"
                   }
                 }
               }
@@ -56,7 +56,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/withswaggerui_types.PostDTO"
+                "$ref": "#/components/schemas/types.PostDTO"
               }
             }
           }
@@ -67,7 +67,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/withswaggerui_types.Post"
+                  "$ref": "#/components/schemas/types.Post"
                 }
               }
             }
@@ -104,7 +104,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/withswaggerui_types.Post"
+                  "$ref": "#/components/schemas/types.Post"
                 }
               }
             }
@@ -137,7 +137,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/withswaggerui_types.PostDTO"
+                "$ref": "#/components/schemas/types.PostDTO"
               }
             }
           }
@@ -148,7 +148,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/withswaggerui_types.Post"
+                  "$ref": "#/components/schemas/types.Post"
                 }
               }
             }
@@ -197,16 +197,15 @@
   },
   "components": {
     "schemas": {
-      "github.com_gin-gonic_gin.H": {
+      "gin.H": {
         "type": "object",
         "additionalProperties": {}
       },
       "time.Time": {
         "type": "string",
-        "format": "date-time",
-        "description": "A Time represents an instant in time with nanosecond precision.\n\nPrograms using times should typically store and pass them as values,\nnot pointers. That is, time variables and struct fields should be of\ntype time.Time, not *time.Time.\n\nA Time value can be used by multiple goroutines simultaneously except\nthat the methods GobDecode, UnmarshalBinary, UnmarshalJSON and\nUnmarshalText are not concurrency-safe.\n\nTime instants can be compared using the Before, After, and Equal methods.\nThe Sub method subtracts two instants, producing a Duration.\nThe Add method adds a Time and a Duration, producing a Time.\n\nThe zero value of type Time is January 1, year 1, 00:00:00.000000000 UTC.\nAs this time is unlikely to come up in practice, the IsZero method gives\na simple way of detecting a time that has not been initialized explicitly.\n\nEach Time has associated with it a Location, consulted when computing the\npresentation form of the time, such as in the Format, Hour, and Year methods.\nThe methods Local, UTC, and In return a Time with a specific location.\nChanging the location in this way changes only the presentation; it does not\nchange the instant in time being denoted and therefore does not affect the\ncomputations described in earlier paragraphs.\n\nRepresentations of a Time value saved by the GobEncode, MarshalBinary,\nMarshalJSON, and MarshalText methods store the Time.Location's offset, but not\nthe location name. They therefore lose information about Daylight Saving Time.\n\nIn addition to the required “wall clock” reading, a Time may contain an optional\nreading of the current process's monotonic clock, to provide additional precision\nfor comparison or subtraction.\nSee the “Monotonic Clocks” section in the package documentation for details.\n\nNote that the Go == operator compares not just the time instant but also the\nLocation and the monotonic clock reading. Therefore, Time values should not\nbe used as map or database keys without first guaranteeing that the\nidentical Location has been set for all values, which can be achieved\nthrough use of the UTC or Local method, and that the monotonic clock reading\nhas been stripped by setting t = t.Round(0). In general, prefer t.Equal(u)\nto t == u, since t.Equal uses the most accurate comparison available and\ncorrectly handles the case when only one of its arguments has a monotonic\nclock reading."
+        "format": "date-time"
       },
-      "withswaggerui_types.Author": {
+      "types.Author": {
         "type": "object",
         "properties": {
           "first_name": {
@@ -221,11 +220,11 @@
           }
         }
       },
-      "withswaggerui_types.Comment": {
+      "types.Comment": {
         "type": "object",
         "properties": {
           "author": {
-            "$ref": "#/components/schemas/withswaggerui_types.Author"
+            "$ref": "#/components/schemas/types.Author"
           },
           "body": {
             "type": "string"
@@ -236,11 +235,11 @@
           }
         }
       },
-      "withswaggerui_types.Post": {
+      "types.Post": {
         "type": "object",
         "properties": {
           "author": {
-            "$ref": "#/components/schemas/withswaggerui_types.Author"
+            "$ref": "#/components/schemas/types.Author"
           },
           "body": {
             "type": "string"
@@ -248,7 +247,7 @@
           "comments": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/withswaggerui_types.Comment"
+              "$ref": "#/components/schemas/types.Comment"
             }
           },
           "id": {
@@ -263,7 +262,7 @@
           }
         }
       },
-      "withswaggerui_types.PostDTO": {
+      "types.PostDTO": {
         "type": "object",
         "properties": {
           "author_id": {

--- a/outputs/openapi/components.go
+++ b/outputs/openapi/components.go
@@ -1,8 +1,93 @@
 package openapi
 
 import (
+	"github.com/ls6-events/astra"
+	"slices"
 	"strings"
 )
+
+// collisionSafeNames is a map of a full name package path to a collision safe name
+var collisionSafeNames = make(map[string]string)
+
+// collisionSafeKey creates a key for the collisionSafeNames map
+func collisionSafeKey(name, pkg string) string {
+	return pkg + "." + name
+}
+
+// getPackageName gets the package name from the package path (i.e. github.com/ls6-events/astra -> astra)
+func getPackageName(pkg string) string {
+	return pkg[strings.LastIndex(pkg, "/")+1:]
+}
+
+// makeCollisionSafeNamesFromComponents creates collision safe names for the components
+// This needs to be run before any routes or components are generated
+// As the makeComponentRefName function relies on the collisionSafeNames map
+func makeCollisionSafeNamesFromComponents(components []astra.Field) {
+	// Group the components by package name
+	packageNames := make(map[string][]astra.Field)
+	for _, component := range components {
+		packageName := getPackageName(component.Package)
+
+		// If the package name doesn't exist in the map, create it
+		if _, ok := packageNames[packageName]; !ok {
+			packageNames[packageName] = make([]astra.Field, 0)
+		}
+
+		// Append the component to the package name
+		packageNames[packageName] = append(packageNames[packageName], component)
+	}
+
+	for _, components := range packageNames {
+		// Iterate over every component and see if there is ever a case where the full package path doesn't match up
+		sameUntil := 0
+		for i := 0; i < len(components)-1; i++ {
+			for j := i + 1; j < len(components)-i; j++ {
+				// If the packages don't match, we need to find the first point where they don't match
+				if components[i].Package != components[j].Package {
+					// Create a slice of the package path split by "/"
+					iComponentPackageSplit := strings.Split(components[i].Package, "/")
+					jComponentPackageSplit := strings.Split(components[j].Package, "/")
+
+					// Reverse the package path so we can iterate from the end first
+					slices.Reverse(iComponentPackageSplit)
+					slices.Reverse(jComponentPackageSplit)
+
+					// Iterate over the package path slices and find the first point where they don't match
+					for k := 0; k < len(iComponentPackageSplit) && k < len(jComponentPackageSplit); k++ {
+						if iComponentPackageSplit[k] != jComponentPackageSplit[k] {
+							// We've found the first point where they don't match, set sameUntil to k and break out of the loop
+							sameUntil = k
+							break
+						}
+					}
+					break
+				}
+			}
+		}
+
+		// Iterate over every component and create a collision safe name
+		for _, component := range components {
+			// If sameUntil is greater than 0, we need to remove the package path up to the point where they first don't match
+			if sameUntil > 0 {
+				// Split the package path by "/"
+				splitPackage := strings.Split(component.Package, "/")
+
+				// Pick the final part of the package path, guided by sameUntil
+				// We add 1 because we want to access the first different part of the package path
+				// e.g. github.com/ls6-events/astra and github.com/different/astra would give us sameUntil = 1
+				// and split into "ls6-events" and "different"
+
+				splitPackage = splitPackage[len(splitPackage)-(sameUntil+1):]
+
+				// Join the path back together
+				collisionSafeNames[collisionSafeKey(component.Name, component.Package)] = strings.Join(splitPackage, ".") + "." + component.Name
+			} else {
+				// If sameUntil is 0, we can just use the package name
+				collisionSafeNames[collisionSafeKey(component.Name, component.Package)] = getPackageName(component.Package) + "." + component.Name
+			}
+		}
+	}
+}
 
 // makeComponentRef creates a reference to the component in the OpenAPI specification
 func makeComponentRef(name, pkg string) string {
@@ -11,5 +96,77 @@ func makeComponentRef(name, pkg string) string {
 
 // makeComponentRefName converts the component and package name to a valid OpenAPI reference name (to avoid collisions)
 func makeComponentRefName(name, pkg string) string {
-	return strings.ReplaceAll(pkg, "/", "_") + "." + name
+	return collisionSafeNames[collisionSafeKey(name, pkg)]
+}
+
+// componentToSchema converts a component to a schema
+func componentToSchema(component astra.Field) Schema {
+	var schema Schema
+
+	if component.Type == "struct" {
+		embeddedProperties := make([]Schema, 0)
+		schema = Schema{
+			Type:       "object",
+			Properties: make(map[string]Schema),
+		}
+		for key, field := range component.StructFields {
+			// We should aim to use doc comments in the future
+			// However https://github.com/OAI/OpenAPI-Specification/issues/1514
+			if field.IsEmbedded {
+				embeddedProperties = append(embeddedProperties, Schema{
+					Ref: makeComponentRef(field.Type, field.Package),
+				})
+				continue
+			}
+
+			schema.Properties[key] = componentToSchema(field)
+		}
+
+		if len(embeddedProperties) > 0 {
+			if len(schema.Properties) == 0 {
+				schema.AllOf = embeddedProperties
+			} else {
+				schema.AllOf = append(embeddedProperties, Schema{
+					Properties: schema.Properties,
+				})
+
+				schema.Properties = nil
+			}
+		}
+	} else if component.Type == "slice" {
+		itemSchema := mapAcceptedType(component.SliceType)
+
+		if itemSchema.Type == "" && !astra.IsAcceptedType(component.SliceType) {
+			itemSchema = Schema{
+				Ref: makeComponentRef(component.SliceType, component.Package),
+			}
+		}
+
+		schema = Schema{
+			Type:  "array",
+			Items: &itemSchema,
+		}
+	} else if component.Type == "map" {
+		additionalProperties := mapAcceptedType(component.MapValueType)
+
+		if additionalProperties.Type == "" && !astra.IsAcceptedType(component.MapValueType) {
+			additionalProperties.Ref = makeComponentRef(component.MapValueType, component.Package)
+		}
+
+		schema = Schema{
+			Type:                 "object",
+			AdditionalProperties: &additionalProperties,
+		}
+	} else {
+		schema = mapAcceptedType(component.Type)
+		if schema.Type == "" && !astra.IsAcceptedType(component.Type) {
+			schema = Schema{
+				Ref: makeComponentRef(component.Type, component.Package),
+			}
+		} else {
+			schema.Enum = component.EnumValues
+		}
+	}
+
+	return schema
 }

--- a/outputs/openapi/components_test.go
+++ b/outputs/openapi/components_test.go
@@ -1,0 +1,85 @@
+package openapi
+
+import (
+	"github.com/ls6-events/astra"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCollisionSafeKey(t *testing.T) {
+	key := collisionSafeKey("example", "package")
+	expected := "package.example"
+	assert.Equal(t, expected, key)
+}
+
+func TestGetPackageName(t *testing.T) {
+	pkg := "github.com/ls6-events/astra"
+	expected := "astra"
+	name := getPackageName(pkg)
+	assert.Equal(t, expected, name)
+}
+
+func TestMakeComponentRef(t *testing.T) {
+	collisionSafeNames = make(map[string]string)
+
+	name := "example"
+	pkg := "package"
+	collisionSafeNames[collisionSafeKey(name, pkg)] = "something.else"
+	expected := "#/components/schemas/something.else"
+	ref := makeComponentRef(name, pkg)
+	assert.Equal(t, expected, ref)
+}
+
+func TestMakeComponentRefName(t *testing.T) {
+	collisionSafeNames = make(map[string]string)
+
+	name := "example"
+	pkg := "package"
+	collisionSafeNames[collisionSafeKey(name, pkg)] = "pkg.example"
+	expected := "pkg.example"
+	refName := makeComponentRefName(name, pkg)
+	assert.Equal(t, expected, refName)
+}
+
+func TestMakeCollisionSafeNamesFromComponents(t *testing.T) {
+	collisionSafeNames = make(map[string]string)
+
+	// Initialize a sample list of astra.Field components
+	components := []astra.Field{
+		{
+			Name:    "Field1",
+			Package: "github.com/example/package1",
+		},
+		{
+			Name:    "Field2",
+			Package: "github.com/example/package2",
+		},
+		{
+			Name:    "Field3",
+			Package: "github.com/another/package1",
+		},
+	}
+
+	// Call the function to generate collisionSafeNames
+	makeCollisionSafeNamesFromComponents(components)
+
+	// Define expected collision-safe names
+	expectedNames := map[string]string{
+		collisionSafeKey("Field1", "github.com/example/package1"): "example.package1.Field1",
+		collisionSafeKey("Field2", "github.com/example/package2"): "package2.Field2",
+		collisionSafeKey("Field3", "github.com/another/package1"): "another.package1.Field3",
+	}
+
+	// Compare the generated collisionSafeNames with the expected names
+	for key, expectedValue := range expectedNames {
+		actualValue, ok := collisionSafeNames[key]
+		if !ok {
+			t.Errorf("Expected key %s not found in collisionSafeNames", key)
+		} else if actualValue != expectedValue {
+			assert.Equal(t, expectedValue, actualValue)
+		}
+	}
+
+	// Clean up by resetting the collisionSafeNames map
+	collisionSafeNames = make(map[string]string)
+}


### PR DESCRIPTION
Instead of assuming worst case by default, we can now calculate component names based on collision avoidance where possible. Shortens the component name where appropriate.

As you can see it goes from `basic_types.Type` to `types.Type` if there is no colliding package with that same name.

For example, `database/sql` and `db-2/sql` would result in `database.sql.X` and `db-2.sql.X`. It'll only iterate up on a package name collision