### PR TITLE
documentation: Use reference when pointing to newly created objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ func main() {
 	gen := astra.New(inputs.WithGinInput(r), outputs.WithOpenAPIOutput("openapi.generated.yaml"))
 
 	// For OpenAPI to work, we need to define a configuration, which contains the title, version and description amongst other important information
-	config := astra.Config{
+	config := &astra.Config{
 		Title:   "Example API",
 		Version: "1.0.0",
 		Host:    "localhost",
@@ -81,7 +81,7 @@ func main() {
 	}
 	
 	// Or you can use our config builder, which will set the host to "localhost" by default, and will validate the configuration to test if it is valid.
-	config, err := astra.NewConfigBuilder().SetTitle("Example API").SetVersion("1.0.0").SetPort(8000).SetSecure(false).Build()
+	config, err := &astra.NewConfigBuilder().SetTitle("Example API").SetVersion("1.0.0").SetPort(8000).SetSecure(false).Build()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Config is used later down the line, and requires a casting otherwise.