### PR TITLE
chore(ci): create sync dependencies pipeline

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,45 @@
+name: Sync Dependencies
+on:
+  pull_request:
+    branches:
+      - 'main'
+    types:
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
+jobs:
+  sync-dependencies:
+    if: startsWith(github.actor, 'dependabot')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.0
+      - name: Sync all dependencies
+        run: |
+          find . -name 'go.mod' -execdir go mod tidy \;
+      - name: Check for changes
+        id: git_status
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "has_changes=true" >> $GITHUB_ENV
+          else
+            echo "has_changes=false" >> $GITHUB_ENV
+          fi
+      - name: Commit and push changes
+        if: env.has_changes == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore(deps): sync updated dependencies [dependabot skip]"
+          git push origin HEAD:${{ github.head_ref }}
+      - name: No changes
+        if: env.has_changes == 'false'
+        run: |
+          echo "No changes detected"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,7 +9,7 @@ on:
       - 'reopened'
 jobs:
   sync-dependencies:
-    if: startsWith(github.actor, 'dependabot')
+    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR creates a new pipeline that automatically syncs all of the dependencies of the sub projects during a `Dependabot` PR. This works by running `go mod tidy` against all of the `go.mod`s in the project. This should fix the issue where `Dependabot` PRs were causing the dependencies of the sub projects to become out of sync with the core dependencies.